### PR TITLE
chore: unify site branding from AI Scream to PignuAnte

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Screams</title>
+    <title>PignuAnte</title>
     <!-- Pixel fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -19,7 +19,7 @@
     <!-- Color scheme init (prevents flash on reload) -->
     <script>
       (function () {
-        var s = localStorage.getItem("ai-scream-scheme");
+        var s = localStorage.getItem("pignuante-scheme");
         if (s && /^(aurora|peach|cotton|matcha)$/.test(s)) {
           document.documentElement.setAttribute("data-scheme", s);
         }

--- a/public/404.html
+++ b/public/404.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>AI Screams</title>
+    <title>PignuAnte</title>
     <script>
       // GitHub Pages SPA fallback
       // Saves the current path and redirects to index.html

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -64,7 +64,7 @@ export default function Footer() {
           {/* Copyright + GitHub */}
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-[var(--text-secondary)]">
-              &copy; {YEAR} AI Scream
+              &copy; {YEAR} PignuAnte
             </p>
             <a
               aria-label="GitHub 저장소"

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -75,7 +75,7 @@ export default function Navbar() {
           className="font-pixel text-sm font-semibold tracking-tight text-[var(--text-primary)]"
           to="/"
         >
-          AI Scream
+          PignuAnte
         </Link>
 
         {/* Desktop nav */}

--- a/src/contexts/SchemeContext.tsx
+++ b/src/contexts/SchemeContext.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import type { ColorScheme } from "../styles/tokens";
 
-const STORAGE_KEY = "ai-scream-scheme";
+const STORAGE_KEY = "pignuante-scheme";
 const VALID_SCHEMES = new Set<ColorScheme>([
   "aurora",
   "cotton",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -68,7 +68,7 @@ export default function Home(): JSX.Element {
         style={{ color: "var(--text-brand)" }}
         variants={titleMotionVariants}
       >
-        ★ AI SCREAM ★
+        ★ PIGNUANTE ★
       </motion.h1>
 
       <motion.p

--- a/src/pages/about/data.ts
+++ b/src/pages/about/data.ts
@@ -28,7 +28,7 @@ export const CHARACTER_INFO: Readonly<CharacterInfo> = {
 };
 
 export const CHARACTER_BIO: string =
-  "AI Scream 왕국의 PignuAnte입니다.\n코드라는 마법을 다루며, 새로운 던전(프로젝트)을 탐험하고\n버그라는 몬스터를 처치하는 것이 일상입니다.\n가끔은 월드맵(세계 여행)을 떠나기도 합니다.";
+  "PignuAnte 왕국의 주인 PignuAnte입니다.\n코드라는 마법을 다루며, 새로운 던전(프로젝트)을 탐험하고\n버그라는 몬스터를 처치하는 것이 일상입니다.\n가끔은 월드맵(세계 여행)을 떠나기도 합니다.";
 
 export const CHARACTER_STATS: readonly CharacterStat[] = [
   { id: "race", label: "RACE", value: CHARACTER_INFO.race },
@@ -143,7 +143,7 @@ export const INVENTORY_ITEMS: readonly InventoryItem[] = [
 export const QUEST_ENTRIES: readonly QuestEntry[] = [
   {
     description:
-      "AI Scream 왕국의 포털(포트폴리오 사이트)을 픽셀 마법으로 건설",
+      "PignuAnte 왕국의 포털(포트폴리오 사이트)을 픽셀 마법으로 건설",
     id: "quest-kingdom-portal",
     period: "2024.01 - 현재",
     status: "IN PROGRESS",

--- a/src/pages/home/components/IntroDialog.tsx
+++ b/src/pages/home/components/IntroDialog.tsx
@@ -45,7 +45,7 @@ export default function IntroDialog({
       <div className="mb-3 flex items-center justify-between gap-2">
         <PixelDialogHeader
           iconColor="var(--surface-elevated)"
-          label="AI Scream"
+          label="PignuAnte"
         />
         {dialogOpen && (
           <button

--- a/src/pages/home/constants.ts
+++ b/src/pages/home/constants.ts
@@ -11,4 +11,4 @@ export const HOME_MENU_ITEMS: ReadonlyArray<HomeMenuItem> = [
 ];
 
 export const HOME_INTRO_TEXT: string =
-  "안녕하세요! AI Scream의 픽셀 세계에 오신 것을 환영합니다.\n이곳은 개발자이자 여행자의 디지털 공간입니다.\n프로젝트와 여행 기록, 그리고 다양한 이야기들이\n여러분을 기다리고 있습니다. ★";
+  "안녕하세요! PignuAnte의 픽셀 세계에 오신 것을 환영합니다.\n이곳은 개발자이자 여행자의 디지털 공간입니다.\n프로젝트와 여행 기록, 그리고 다양한 이야기들이\n여러분을 기다리고 있습니다. ★";

--- a/src/pages/projects/summary-data.ts
+++ b/src/pages/projects/summary-data.ts
@@ -16,7 +16,7 @@ export const PROJECT_SUMMARIES: readonly ProjectSummary[] = [
   {
     links: {
       demoUrl: "https://example.com/pixel-kingdom",
-      repoUrl: "https://github.com/aiscream/pixel-kingdom",
+      repoUrl: "https://github.com/pignuante/pixel-kingdom",
     },
     period: "2025.11 - 2026.01",
     questTier: "MAIN",
@@ -26,7 +26,7 @@ export const PROJECT_SUMMARIES: readonly ProjectSummary[] = [
     status: "LIVE",
     subtitle: "왕국 포털 리빌드",
     summary:
-      "AI Scream 포트폴리오를 RPG 스타일로 재구성한 핵심 리빌드 프로젝트",
+      "PignuAnte 포트폴리오를 RPG 스타일로 재구성한 핵심 리빌드 프로젝트",
     thumbnail: {
       alt: "픽셀 킹덤 포털의 카드형 대시보드 화면",
       caption: "Portal UI",
@@ -35,7 +35,7 @@ export const PROJECT_SUMMARIES: readonly ProjectSummary[] = [
   },
   {
     links: {
-      repoUrl: "https://github.com/aiscream/dungeon-party-planner",
+      repoUrl: "https://github.com/pignuante/dungeon-party-planner",
     },
     period: "2025.06 - 2025.08",
     questTier: "MAIN",

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,5 +1,5 @@
 /**
- * AI Scream - Design Tokens (TypeScript)
+ * PignuAnte - Design Tokens (TypeScript)
  *
  * JS-accessible token values for use outside CSS context
  * (e.g., PixiJS canvas rendering, Motion animation configs).


### PR DESCRIPTION
## 요약

사이트 브랜딩을 "AI Scream" → **PignuAnte**로 통일합니다. (About 페이지 캐릭터명과 일치)

## 변경 내용

**사용자에게 보이는 텍스트:**
- 탭 제목: index.html, public/404.html → PignuAnte
- 상단 로고(Navbar), 히어로(Home ★ PIGNUANTE ★), 인트로 다이얼로그, 푸터 저작권
- 한글 카피: home 인트로, about 소개/퀘스트, projects 설명

**내부 식별자:**
- 색상 테마 localStorage 키 ai-scream-scheme → pignuante-scheme (index.html + SchemeContext 동기화)
- 더미 프로젝트 repo URL github.com/aiscream/* → github.com/pignuante/*
- tokens.ts 주석

## 참고

- localStorage 키 변경으로 기존 방문자의 저장된 색상 테마는 1회 기본값으로 초기화됩니다(수용).
- npm run build / lint / format:check / tsc 통과.